### PR TITLE
mark dist as deprecated in metadata

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Tree-File
 
+0.113   2015-02-??
+        - Added github repo to dist metadata
+
 0.112   2013-01-01
         Don't bother trying to install on Win32.  Locking times out, and nobody
         should be using this anyway.

--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for Tree-File
 
 0.113   2015-02-??
         - Added github repo to dist metadata
+        - Added x_deprecated to dist metadata to tag dist as deprecated
 
 0.112   2013-01-01
         Don't bother trying to install on Win32.  Locking times out, and nobody

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,6 +5,12 @@ use ExtUtils::MakeMaker;
 die "Win32 is currently not supported due to timeouts in t/collapse.t\n"
   if $^O eq 'MSWin32';
 
+my $mm_ver = $ExtUtils::MakeMaker::VERSION;
+if ($mm_ver =~ /_/) { # developer release
+    $mm_ver = eval $mm_ver;
+    die $@ if $@;
+}
+
 WriteMakefile(
     NAME                => 'Tree::File',
     AUTHOR              => 'Ricardo Signes <rjbs@cpan.org>',
@@ -18,4 +24,19 @@ WriteMakefile(
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'Tree-File-* cover_db errors.err' },
+
+    ($mm_ver <= 6.45
+        ? ()
+        : (META_MERGE => {
+            'meta-spec' => { version => 2 },
+            resources => {
+                repository  => {
+                    type => 'git',
+                    web  => 'https://github.com/rjbs/tree-file',
+                    url  => 'https://github.com/rjbs/tree-file.git',
+                },
+            },
+          })
+    ),
+
 );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -28,6 +28,7 @@ WriteMakefile(
     ($mm_ver <= 6.45
         ? ()
         : (META_MERGE => {
+            x_deprecated => 1,
             'meta-spec' => { version => 2 },
             resources => {
                 repository  => {

--- a/lib/Tree/File.pm
+++ b/lib/Tree/File.pm
@@ -12,11 +12,11 @@ Tree::File - (DEPRECATED) store a data structure in a file tree
 
 =head1 VERSION
 
-version 0.112
+version 0.113
 
 =cut
 
-our $VERSION = '0.112';
+our $VERSION = '0.113';
 
 =head1 SYNOPSIS
 

--- a/lib/Tree/File/YAML.pm
+++ b/lib/Tree/File/YAML.pm
@@ -16,11 +16,11 @@ Tree::File::YAML - (DEPRECATED) store a data structure in a file tree (using YAM
 
 =head1 VERSION
 
-version 0.112
+version 0.113
 
 =cut
 
-our $VERSION = '0.112';
+our $VERSION = '0.113';
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
I'm working through adding metadata tag to deprecated dists. MetaCPAN is going use this tag to identify deprecated dists, so they don't have to rely on a regex on the abstract.

Plus for the PRC I ignore github repos where they have the `x_deprecated` field in the metadata.
